### PR TITLE
Singularity bugfix: keep report log file list in local workdir

### DIFF
--- a/modules/local/enchantr/report_file_size.nf
+++ b/modules/local/enchantr/report_file_size.nf
@@ -21,12 +21,8 @@ process REPORT_FILE_SIZE {
     path "file_size_report/tables/log_data.tsv", emit: table
 
     script:
-    def all_logs = logs.join('\n')
-    def logs_file = workDir + '/logs.txt'
-    logs_file = file(logs_file)
-    logs_file.text = all_logs
     """
-    mv "${logs_file}" .
+    echo "${logs.join('\n')}" > logs.txt
     Rscript -e "enchantr::enchantr_report('file_size', \\
         report_params=list('input'='logs.txt', 'metadata'='${metadata}',\\
         'outdir'=getwd()))"


### PR DESCRIPTION
Tiny bugfix for airrflow/reveal: 

I was getting file-not-found errors for the temporary log file in the REPORT_FILE_SIZE step. Pretty sure this was a singularity bind mounts issue from leaving the log file list in the global `workDir` instead of the process-specific local dir. The commit below seems to work around this without issue.

Thanks and happy 2023! 


## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/airrflow/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/airrflow _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
