### PR TITLE
Add public_aws_ecr profile

### DIFF
--- a/.github/workflows/awsfulltest.yml
+++ b/.github/workflows/awsfulltest.yml
@@ -24,7 +24,7 @@ jobs:
             {
               "outdir": "s3://${{ secrets.AWS_S3_BUCKET }}/airrflow/results-${{ github.sha }}"
             }
-          profiles: test_full,aws_tower
+          profiles: test_full,aws_tower,public_aws_ecr
       - uses: actions/upload-artifact@v3
         with:
           name: Tower debug log file

--- a/.github/workflows/awstest.yml
+++ b/.github/workflows/awstest.yml
@@ -22,7 +22,7 @@ jobs:
             {
               "outdir": "s3://${{ secrets.AWS_S3_BUCKET }}/airrflow/results-test-${{ github.sha }}"
             }
-          profiles: test,aws_tower
+          profiles: test,aws_tower,public_aws_ecr
       - uses: actions/upload-artifact@v3
         with:
           name: Tower debug log file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [#250](https://github.com/nf-core/airrflow/pull/250) Back to `dev`.
 - [#256](https://github.com/nf-core/airrflow/pull/256) Merge template updates to nf-core tools 2.8.
 - [#263](https://github.com/nf-core/airrflow/pull/263) Bump versions to 3.1.
+- [##] Added `public_aws_ecr` for using ECR containers
 
 ### `Fixed`
 

--- a/conf/public_aws_ecr.config
+++ b/conf/public_aws_ecr.config
@@ -1,0 +1,27 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    AWS ECR Config
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Config to set public AWS ECR images wherever possible
+    This improves speed when running on AWS infrastructure.
+    Use this as an example template when using your own private registry.
+----------------------------------------------------------------------------------------
+*/
+
+docker.registry = 'public.ecr.aws'
+podman.registry = 'public.ecr.aws'
+
+process {
+    withName: 'FASTQC' {
+        container = 'quay.io/biocontainers/fastqc:0.11.9--0'
+    }
+    withName: 'FASTQC_POSTASSEMBLY' {
+        container = 'quay.io/biocontainers/fastqc:0.11.9--0'
+    }
+    withName: 'MERGE_UMI' {
+        container = 'quay.io/biocontainers/mulled-v2-adc9bb9edc31eb38b3c24786a83b7dfa530e2bea:47d6d7765d7537847ced7dac873190d164146022-0'
+    }
+    withName: 'RENAME_FASTQ' {
+        container = 'quay.io/biocontainers/mulled-v2-adc9bb9edc31eb38b3c24786a83b7dfa530e2bea:47d6d7765d7537847ced7dac873190d164146022-0'
+    }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -252,6 +252,9 @@ profiles {
         executor.cpus          = 16
         executor.memory        = 60.GB
     }
+    public_aws_ecr {
+        includeConfig 'conf/public_aws_ecr.config'
+    }
     test      { includeConfig 'conf/test.config'      }
     test_full { includeConfig 'conf/test_full.config' }
     test_tcr { includeConfig 'conf/test_tcr.config' }
@@ -285,6 +288,12 @@ env {
 
 // Capture exit codes from upstream processes when piping
 process.shell = ['/bin/bash', '-euo', 'pipefail']
+
+// Set default registry for Docker and Podman independent of -profile
+// Will not be used unless Docker / Podman are enabled
+// Set to your registry if you have a mirror of containers
+docker.registry = 'quay.io'
+podman.registry = 'quay.io'
 
 def trace_timestamp = new java.util.Date().format( 'yyyy-MM-dd_HH-mm-ss')
 timeline {


### PR DESCRIPTION
Adds public_aws_ecr profile for using public containers hosted on AWS ECR instead of quay.io. Used in full tests on AWS.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/airrflow/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/airrflow _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
