### PR TITLE
clonal_threshold accepts multiple values in nextflow_schema.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### `Fixed`
 
 - Removed optional output from FilterQuality to not fail silently
+- clonal_threshold is validated to be 'auto' or number greater than zero
 
 ### `Dependencies`
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -190,7 +190,7 @@ profiles {
     }
     docker {
         docker.enabled         = true
-        docker.userEmulation   = true
+        docker.runOptions      = '-u $(id -u):$(id -g)'
         conda.enabled          = false
         singularity.enabled    = false
         podman.enabled         = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,10 +10,7 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": [
-                "input",
-                "outdir"
-            ],
+            "required": ["input", "outdir"],
             "properties": {
                 "input": {
                     "type": "string",
@@ -30,10 +27,7 @@
                     "type": "string",
                     "default": "fastq",
                     "description": "Specify the processing mode for the pipeline. Available options are \"fastq\" and \"assembled\".",
-                    "enum": [
-                        "fastq",
-                        "assembled"
-                    ],
+                    "enum": ["fastq", "assembled"],
                     "fa_icon": "fas fa-terminal"
                 },
                 "outdir": {
@@ -67,12 +61,7 @@
                     "type": "string",
                     "fa_icon": "fas fa-flask",
                     "description": "Protocol used for the V(D)J amplicon sequencing library generation.",
-                    "enum": [
-                        "specific_pcr_umi",
-                        "specific_pcr",
-                        "dt_5p_race",
-                        "dt_5p_race_umi"
-                    ],
+                    "enum": ["specific_pcr_umi", "specific_pcr", "dt_5p_race", "dt_5p_race_umi"],
                     "help_text": "Available protocols are:\n- `specific_pcr_umi`: RT-PCR using transcript-specific primers containing UMIs.\n- `specific_pcr`: RT-PCR using transcript-specific primers.\n- `dt_5p_race_umi`: 5\u2019-RACE PCR using oligo-dT primers and template switch primers containing UMI.\n- `dt_5p_race`: 5\u2019-RACE PCR (i.e. RT is followed by a template switch (TS) step) using oligo-dT primers."
                 },
                 "race_linker": {
@@ -116,10 +105,7 @@
                     "default": "R1",
                     "fa_icon": "fas fa-dna",
                     "description": "Indicate if C region primers are in the R1 or R2 reads.",
-                    "enum": [
-                        "R1",
-                        "R2"
-                    ]
+                    "enum": ["R1", "R2"]
                 },
                 "primer_revpr": {
                     "type": "boolean",
@@ -140,10 +126,7 @@
                     "default": "R1",
                     "description": "Indicate if UMI indices are recorded in the R1 (default) or R1 fastq file.",
                     "help_text": "The pipeline requires UMI barcodes for identifying unique transcripts. These barcodes are typically read from an index file but sometimes can be provided merged with the start of the R1 or R2 reads. If provided in an additional index file, set the `--index_file` parameter, if provided merged with the R1 or R2 reads, set the `--umi_position` parameter to R1 or R2, respectively.",
-                    "enum": [
-                        "R1",
-                        "R2"
-                    ],
+                    "enum": ["R1", "R2"],
                     "fa_icon": "fas fa-barcode"
                 },
                 "umi_length": {
@@ -251,12 +234,7 @@
                     "type": "string",
                     "default": "cut",
                     "description": "Masking mode for the pRESTO MaskPrimer step. Available: cut, mask, trim, tag.",
-                    "enum": [
-                        "cut",
-                        "mask",
-                        "trim",
-                        "tag"
-                    ],
+                    "enum": ["cut", "mask", "trim", "tag"],
                     "help_text": "The primer masking modes will perform the following actions:\n\n* `cut`: remove both the primer region and the preceding sequence.\n* `mask`: replace the primer region with Ns and remove the preceding sequence.\n* `trim`: remove the region preceding the primer, but leave the primer region intact.\n* `tag`: leave the input sequence unmodified.",
                     "fa_icon": "fas fa-mask"
                 },
@@ -359,19 +337,14 @@
                     "oneOf": [
                         {
                             "type": "string",
-                            "enum": [
-                                "auto"
-                            ]
+                            "enum": ["auto"]
                         },
                         {
                             "type": "number",
                             "minimum": 0
                         }
                     ],
-                    "type": [
-                        "string",
-                        "number"
-                    ],
+                    "type": ["string", "number"],
                     "default": "auto",
                     "fa_icon": "fab fa-pagelines",
                     "description": "Set the clustering threshold Hamming distance value. Default: 'auto'"
@@ -595,14 +568,7 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": [
-                        "symlink",
-                        "rellink",
-                        "link",
-                        "copy",
-                        "copyNoFollow",
-                        "move"
-                    ],
+                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
                     "hidden": true
                 },
                 "email_on_fail": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,7 +10,10 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": ["input", "outdir"],
+            "required": [
+                "input",
+                "outdir"
+            ],
             "properties": {
                 "input": {
                     "type": "string",
@@ -27,7 +30,10 @@
                     "type": "string",
                     "default": "fastq",
                     "description": "Specify the processing mode for the pipeline. Available options are \"fastq\" and \"assembled\".",
-                    "enum": ["fastq", "assembled"],
+                    "enum": [
+                        "fastq",
+                        "assembled"
+                    ],
                     "fa_icon": "fas fa-terminal"
                 },
                 "outdir": {
@@ -61,7 +67,12 @@
                     "type": "string",
                     "fa_icon": "fas fa-flask",
                     "description": "Protocol used for the V(D)J amplicon sequencing library generation.",
-                    "enum": ["specific_pcr_umi", "specific_pcr", "dt_5p_race", "dt_5p_race_umi"],
+                    "enum": [
+                        "specific_pcr_umi",
+                        "specific_pcr",
+                        "dt_5p_race",
+                        "dt_5p_race_umi"
+                    ],
                     "help_text": "Available protocols are:\n- `specific_pcr_umi`: RT-PCR using transcript-specific primers containing UMIs.\n- `specific_pcr`: RT-PCR using transcript-specific primers.\n- `dt_5p_race_umi`: 5\u2019-RACE PCR using oligo-dT primers and template switch primers containing UMI.\n- `dt_5p_race`: 5\u2019-RACE PCR (i.e. RT is followed by a template switch (TS) step) using oligo-dT primers."
                 },
                 "race_linker": {
@@ -105,7 +116,10 @@
                     "default": "R1",
                     "fa_icon": "fas fa-dna",
                     "description": "Indicate if C region primers are in the R1 or R2 reads.",
-                    "enum": ["R1", "R2"]
+                    "enum": [
+                        "R1",
+                        "R2"
+                    ]
                 },
                 "primer_revpr": {
                     "type": "boolean",
@@ -126,7 +140,10 @@
                     "default": "R1",
                     "description": "Indicate if UMI indices are recorded in the R1 (default) or R1 fastq file.",
                     "help_text": "The pipeline requires UMI barcodes for identifying unique transcripts. These barcodes are typically read from an index file but sometimes can be provided merged with the start of the R1 or R2 reads. If provided in an additional index file, set the `--index_file` parameter, if provided merged with the R1 or R2 reads, set the `--umi_position` parameter to R1 or R2, respectively.",
-                    "enum": ["R1", "R2"],
+                    "enum": [
+                        "R1",
+                        "R2"
+                    ],
                     "fa_icon": "fas fa-barcode"
                 },
                 "umi_length": {
@@ -235,7 +252,12 @@
                     "type": "string",
                     "default": "cut",
                     "description": "Masking mode for the pRESTO MaskPrimer step. Available: cut, mask, trim, tag.",
-                    "enum": ["cut", "mask", "trim", "tag"],
+                    "enum": [
+                        "cut",
+                        "mask",
+                        "trim",
+                        "tag"
+                    ],
                     "help_text": "The primer masking modes will perform the following actions:\n\n* `cut`: remove both the primer region and the preceding sequence.\n* `mask`: replace the primer region with Ns and remove the preceding sequence.\n* `trim`: remove the region preceding the primer, but leave the primer region intact.\n* `tag`: leave the input sequence unmodified.",
                     "fa_icon": "fas fa-mask"
                 },
@@ -335,7 +357,18 @@
             "default": "",
             "properties": {
                 "clonal_threshold": {
-                    "type": ["string", "number"],
+                    "oneOf": [
+                        {
+                            "type": "string",
+                            "enum": [
+                                "auto"
+                            ]
+                        },
+                        {
+                            "type": "number",
+                            "minimum": 0
+                        }
+                    ],
                     "default": "auto",
                     "fa_icon": "fab fa-pagelines",
                     "description": "Set the clustering threshold Hamming distance value. Default: 'auto'"
@@ -559,7 +592,14 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
+                    "enum": [
+                        "symlink",
+                        "rellink",
+                        "link",
+                        "copy",
+                        "copyNoFollow",
+                        "move"
+                    ],
                     "hidden": true
                 },
                 "email_on_fail": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -184,7 +184,6 @@
                 },
                 "adapter_fasta": {
                     "type": "string",
-                    "default": "None",
                     "fa_icon": "fas fa-file",
                     "description": "Fasta file with adapter sequences to be trimmed."
                 },
@@ -368,6 +367,10 @@
                             "type": "number",
                             "minimum": 0
                         }
+                    ],
+                    "type": [
+                        "string",
+                        "number"
                     ],
                     "default": "auto",
                     "fa_icon": "fab fa-pagelines",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -61,7 +61,7 @@
                     "type": "string",
                     "fa_icon": "fas fa-flask",
                     "description": "Protocol used for the V(D)J amplicon sequencing library generation.",
-                    "enum": ["specific_pcr_umi", "specific_pcr", "dt_5p_race", "dt_5p_race_umi"],
+                    "enum": ["dt_5p_race", "dt_5p_race_umi", "specific_pcr", "specific_pcr_umi"],
                     "help_text": "Available protocols are:\n- `specific_pcr_umi`: RT-PCR using transcript-specific primers containing UMIs.\n- `specific_pcr`: RT-PCR using transcript-specific primers.\n- `dt_5p_race_umi`: 5\u2019-RACE PCR using oligo-dT primers and template switch primers containing UMI.\n- `dt_5p_race`: 5\u2019-RACE PCR (i.e. RT is followed by a template switch (TS) step) using oligo-dT primers."
                 },
                 "race_linker": {
@@ -234,7 +234,7 @@
                     "type": "string",
                     "default": "cut",
                     "description": "Masking mode for the pRESTO MaskPrimer step. Available: cut, mask, trim, tag.",
-                    "enum": ["cut", "mask", "trim", "tag"],
+                    "enum": ["cut", "mask", "tag", "trim"],
                     "help_text": "The primer masking modes will perform the following actions:\n\n* `cut`: remove both the primer region and the preceding sequence.\n* `mask`: replace the primer region with Ns and remove the preceding sequence.\n* `trim`: remove the region preceding the primer, but leave the primer region intact.\n* `tag`: leave the input sequence unmodified.",
                     "fa_icon": "fas fa-mask"
                 },


### PR DESCRIPTION
The nextflow_schema.json used invalid JSON schema for clonal_threshold which accepts two types of values. This PR changes it to use the `oneOf` and some validation instead of a list.

Fixes #292 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/airrflow/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/airrflow _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
