### PR TITLE
Dowser tips by isotype

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### `Fixed`
 
 - [#319](https://github.com/nf-core/airrflow/pull/319) Fix test full profile and nebnext_umi_tcr profile.
+- [#321](https://github.com/nf-core/airrflow/pull/321) Label Dowser tips by isotype instead of c_call by default.
 
 ## [3.3.0] - 2024-03-31 Confringo
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -564,8 +564,8 @@ process {
         ]
         ext.args = ['build':'igphyml',
                     'minseq':5,
-                    'traits':'c_call',
-                    'tips':'c_call']
+                    'traits':'isotype',
+                    'tips':'isotype']
     }
 
     // -------------------------------

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -33,8 +33,8 @@ process {
     withName:DOWSER_LINEAGES{
         ext.args = ['build':'igphyml',
                     'minseq':5,
-                    'traits':'c_primer',
-                    'tips':'c_primer']
+                    'traits':'isotype',
+                    'tips':'isotype']
     }
 
     withName:DEFINE_CLONES_COMPUTE{


### PR DESCRIPTION
It's a good idea to label the Dowser tips in the lineage trees by isotype by default now that we label them.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/airrflow/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/airrflow _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nf-test test main.nf.test -profile test,docker`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
