### PR TITLE
Fix #452: publishDir collisions between `PRESTO_PARSE_CLUSTER` and `PRESTO_PAIRSEQ_CLUSTERSETS`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### `Fixed`
 
-- [#453](https://github.com/nf-core/airrflow/pull/413) Fix publishDir collisions in `PRESTO_PARSE_CLUSTER` and `PRESTO_PAIRSEQ_CLUSTERSETS`
+- [#453](https://github.com/nf-core/airrflow/pull/453) Fix publishDir collisions in `PRESTO_PARSE_CLUSTER` and `PRESTO_PAIRSEQ_CLUSTERSETS`
 
 ## [5.0.0] - Tarantallegra
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### `Fixed`
+
+- [#453](https://github.com/nf-core/airrflow/pull/413) Fix publishDir collisions in `PRESTO_PARSE_CLUSTER` and `PRESTO_PAIRSEQ_CLUSTERSETS`
+
 ## [5.0.0] - Tarantallegra
 
 ### `Added`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## 5.0.1 dev [Unreleased]
 
 ### `Fixed`
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -301,7 +301,7 @@ process {
 
     withName: PRESTO_PAIRSEQ_CLUSTERSETS {
         publishDir = [
-            path: { "${params.outdir}/presto/05-parse-clusters/${meta.id}" },
+            path: { "${params.outdir}/presto/05-parse-clusters/pairseq/${meta.id}" },
             mode: params.publish_dir_mode,
             pattern: "*{txt,log,tab}"
         ]

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -532,6 +532,19 @@
                 "presto/05-parse-clusters/Sample7/Sample7_command_log.txt",
                 "presto/05-parse-clusters/Sample8",
                 "presto/05-parse-clusters/Sample8/Sample8_command_log.txt",
+                "presto/05-parse-clusters/pairseq",
+                "presto/05-parse-clusters/pairseq/Sample2",
+                "presto/05-parse-clusters/pairseq/Sample2/Sample2_command_log.txt",
+                "presto/05-parse-clusters/pairseq/Sample3",
+                "presto/05-parse-clusters/pairseq/Sample3/Sample3_command_log.txt",
+                "presto/05-parse-clusters/pairseq/Sample4",
+                "presto/05-parse-clusters/pairseq/Sample4/Sample4_command_log.txt",
+                "presto/05-parse-clusters/pairseq/Sample6",
+                "presto/05-parse-clusters/pairseq/Sample6/Sample6_command_log.txt",
+                "presto/05-parse-clusters/pairseq/Sample7",
+                "presto/05-parse-clusters/pairseq/Sample7/Sample7_command_log.txt",
+                "presto/05-parse-clusters/pairseq/Sample8",
+                "presto/05-parse-clusters/pairseq/Sample8/Sample8_command_log.txt",
                 "presto/06-build-consensus",
                 "presto/06-build-consensus/Sample2",
                 "presto/06-build-consensus/Sample2/Sample2_R1_table.tab",
@@ -906,8 +919,8 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nextflow": "25.04.8"
         },
-        "timestamp": "2026-01-23T13:16:16.218450411"
+        "timestamp": "2026-03-11T13:37:22.894083833"
     }
 }

--- a/tests/test_maskprimers_align.nf.test.snap
+++ b/tests/test_maskprimers_align.nf.test.snap
@@ -506,6 +506,19 @@
                 "presto/05-parse-clusters/Sample7/Sample7_command_log.txt",
                 "presto/05-parse-clusters/Sample8",
                 "presto/05-parse-clusters/Sample8/Sample8_command_log.txt",
+                "presto/05-parse-clusters/pairseq",
+                "presto/05-parse-clusters/pairseq/Sample2",
+                "presto/05-parse-clusters/pairseq/Sample2/Sample2_command_log.txt",
+                "presto/05-parse-clusters/pairseq/Sample3",
+                "presto/05-parse-clusters/pairseq/Sample3/Sample3_command_log.txt",
+                "presto/05-parse-clusters/pairseq/Sample4",
+                "presto/05-parse-clusters/pairseq/Sample4/Sample4_command_log.txt",
+                "presto/05-parse-clusters/pairseq/Sample6",
+                "presto/05-parse-clusters/pairseq/Sample6/Sample6_command_log.txt",
+                "presto/05-parse-clusters/pairseq/Sample7",
+                "presto/05-parse-clusters/pairseq/Sample7/Sample7_command_log.txt",
+                "presto/05-parse-clusters/pairseq/Sample8",
+                "presto/05-parse-clusters/pairseq/Sample8/Sample8_command_log.txt",
                 "presto/06-build-consensus",
                 "presto/06-build-consensus/Sample2",
                 "presto/06-build-consensus/Sample2/Sample2_R1_table.tab",
@@ -876,8 +889,8 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nextflow": "25.04.8"
         },
-        "timestamp": "2026-01-23T13:52:37.955412968"
+        "timestamp": "2026-03-11T14:38:19.045130698"
     }
 }

--- a/tests/test_maskprimers_extract.nf.test.snap
+++ b/tests/test_maskprimers_extract.nf.test.snap
@@ -507,6 +507,19 @@
                 "presto/05-parse-clusters/Sample7/Sample7_command_log.txt",
                 "presto/05-parse-clusters/Sample8",
                 "presto/05-parse-clusters/Sample8/Sample8_command_log.txt",
+                "presto/05-parse-clusters/pairseq",
+                "presto/05-parse-clusters/pairseq/Sample2",
+                "presto/05-parse-clusters/pairseq/Sample2/Sample2_command_log.txt",
+                "presto/05-parse-clusters/pairseq/Sample3",
+                "presto/05-parse-clusters/pairseq/Sample3/Sample3_command_log.txt",
+                "presto/05-parse-clusters/pairseq/Sample4",
+                "presto/05-parse-clusters/pairseq/Sample4/Sample4_command_log.txt",
+                "presto/05-parse-clusters/pairseq/Sample6",
+                "presto/05-parse-clusters/pairseq/Sample6/Sample6_command_log.txt",
+                "presto/05-parse-clusters/pairseq/Sample7",
+                "presto/05-parse-clusters/pairseq/Sample7/Sample7_command_log.txt",
+                "presto/05-parse-clusters/pairseq/Sample8",
+                "presto/05-parse-clusters/pairseq/Sample8/Sample8_command_log.txt",
                 "presto/06-build-consensus",
                 "presto/06-build-consensus/Sample2",
                 "presto/06-build-consensus/Sample2/Sample2_R1_table.tab",
@@ -879,8 +892,8 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nextflow": "25.04.8"
         },
-        "timestamp": "2026-01-23T13:56:24.803902442"
+        "timestamp": "2026-03-11T14:42:32.921116818"
     }
 }

--- a/tests/test_tcr.nf.test.snap
+++ b/tests/test_tcr.nf.test.snap
@@ -374,6 +374,11 @@
                 "presto/05-parse-clusters/Sample1/Sample1_command_log.txt",
                 "presto/05-parse-clusters/Sample2",
                 "presto/05-parse-clusters/Sample2/Sample2_command_log.txt",
+                "presto/05-parse-clusters/pairseq",
+                "presto/05-parse-clusters/pairseq/Sample1",
+                "presto/05-parse-clusters/pairseq/Sample1/Sample1_command_log.txt",
+                "presto/05-parse-clusters/pairseq/Sample2",
+                "presto/05-parse-clusters/pairseq/Sample2/Sample2_command_log.txt",
                 "presto/06-build-consensus",
                 "presto/06-build-consensus/Sample1",
                 "presto/06-build-consensus/Sample1/Sample1_R1_table.tab",
@@ -538,8 +543,8 @@
         ],
         "meta": {
             "nf-test": "0.9.3",
-            "nextflow": "25.10.2"
+            "nextflow": "25.04.8"
         },
-        "timestamp": "2026-01-23T14:21:28.365538325"
+        "timestamp": "2026-03-11T14:41:21.000321979"
     }
 }


### PR DESCRIPTION
Closes #452, fixing collisions between publishDir locations of `PRESTO_PARSE_CLUSTER_UMI` and `PRESTO_PAIRSEQ_CLUSTERSETS`

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [x] `CHANGELOG.md` is updated.